### PR TITLE
Allow use options as locals in static pug templates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,9 +88,7 @@ export default function pugPlugin (options) {
       opts.filename = id
 
       if (matchStaticPattern(id)) {
-
-        // v1.0.4: include pug options in locals as "pug_options"
-        const locals = assign({ pug_options: opts }, config.locals)
+        const locals = config.locals
 
         fn = compile(code, opts)
         body = JSON.stringify(fn(locals)) + ';'

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,8 @@ export default function pugPlugin (options) {
         }
       }
 
+      // TODO this seemes not in use
+      /*
       const deps = fn.dependencies
       if (deps.length > 1) {
         const ins = {}
@@ -116,6 +118,8 @@ export default function pugPlugin (options) {
           ins[dep] = output.push(`import '${dep}';`)
         })
       }
+      */
+      // `ins` not in use below this point
 
       output.push(`export default ${body}`)
 

--- a/test/fixtures/precompile/main.js
+++ b/test/fixtures/precompile/main.js
@@ -1,4 +1,6 @@
 import html from './template.static.pug'
 
+assert(html.match(/<p>.*?template.static.pug<\/p>/))
 assert(~html.indexOf('<p>pug</p>'))
+assert(~html.indexOf('<p>option_local</p>'))
 assert(~html.indexOf('<p>other</p>'))

--- a/test/fixtures/precompile/template.static.pug
+++ b/test/fixtures/precompile/template.static.pug
@@ -1,2 +1,4 @@
+p= filename
+p= option_local
 p= name
 p= other

--- a/test/run.js
+++ b/test/run.js
@@ -93,7 +93,8 @@ describe('rollup-plugin-pug', function () {
     rollup({
       entry: 'fixtures/precompile/main.js',
       plugins: [_pug({
-        locals: { name: 'pug', other: 'other' }
+        locals: { name: 'pug', other: 'other' },
+        option_local: 'option_local',
       })]
     })
     .then(function (bundle) {


### PR DESCRIPTION
Fixes #5. As I mentioned before, static pug imports can be compiled via `pug.render`, because they don't require dependencies (the whole result is a string). In that case it is possible to use options as locals, just like [Pug itself does](https://pugjs.org/api/reference.html#pugrendersource-options-callback).

I also mentioned that `ins` collection is not in use in code, so dependencies is actually not taking into account. This may be an issue, need your help here @aMarCruz 

I've updated the tests too, but must notice that tests is loose. I think *exact string equality* should be used here, so we can be absolutely sure what exactly plugin yields.