### PR TITLE
fix (this.warn is not a function)

### DIFF
--- a/dist/rollup-plugin-pug.js
+++ b/dist/rollup-plugin-pug.js
@@ -182,7 +182,6 @@ function pugPlugin(options) {
                     config.basedir = path.dirname(path.resolve(basedir));
                 }
                 else {
-                    this.warn('Rollup `input` is not a string, using working dir as `basedir`');
                     config.basedir = path.resolve('.');
                 }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ export default function pugPlugin (options: Partial<PugPluginOpts>): Plugin {
         if (basedir && typeof basedir == 'string') {
           config.basedir = dirname(resolve(basedir))
         } else {
-          this.warn('Rollup `input` is not a string, using working dir as `basedir`')
           config.basedir = resolve('.')
         }
       }


### PR DESCRIPTION
rollup version 1.7.0 crashes with the error "this.warn is not a function" when you use an array as options.input instead of a string.